### PR TITLE
Replace deprecated asyncio.iscoroutinefunction

### DIFF
--- a/kaleidescape/dispatcher.py
+++ b/kaleidescape/dispatcher.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import functools
+import inspect
 import logging
 from collections.abc import Awaitable, Callable
 from typing import Any
@@ -66,6 +67,6 @@ class Dispatcher:
         check_target = target
         while isinstance(check_target, functools.partial):
             check_target = check_target.func
-        if asyncio.iscoroutinefunction(check_target):
+        if inspect.iscoroutinefunction(check_target):
             return self._loop.create_task(target(*args))
         target(*args)


### PR DESCRIPTION
Python 3.14 will deprecated `asyncio.iscoroutinefunction` in favor of `inspect.iscoroutinefunction` which has been available for some time now.

https://docs.python.org/3.14/deprecations/pending-removal-in-3.16.html
https://docs.python.org/3.14/library/inspect.html#inspect.iscoroutinefunction