### PR TITLE
Handle unknown error codes in RESPONSE_ERROR lookups

### DIFF
--- a/kaleidescape/error.py
+++ b/kaleidescape/error.py
@@ -39,7 +39,7 @@ class MessageError(KaleidescapeError, RuntimeError):
 
     def __init__(self, code: int, message: str | None = None):
         self.code = code
-        self.error = const.RESPONSE_ERROR[code]
+        self.error = const.RESPONSE_ERROR.get(code, f"Unknown error ({code})")
         super().__init__(self.error + (f" for command '{message}'" if message else ""))
 
 
@@ -48,5 +48,5 @@ class MessageParseError(KaleidescapeError, ValueError):
 
     def __init__(self, code: int, message: str):
         self.code = code
-        self.error = const.RESPONSE_ERROR[code]
+        self.error = const.RESPONSE_ERROR.get(code, f"Unknown error ({code})")
         super().__init__(self.error + (f" for command '{message}'" if message else ""))

--- a/kaleidescape/message.py
+++ b/kaleidescape/message.py
@@ -353,7 +353,7 @@ class Response(Message):
     @property
     def error(self) -> str:
         """Returns text associated with this message's status."""
-        return const.RESPONSE_ERROR[self._status]
+        return const.RESPONSE_ERROR.get(self._status, f"Unknown error ({self._status})")
 
     @property
     def fields(self) -> list[str]:


### PR DESCRIPTION
## Summary

- Replace direct `dict[key]` lookups on `RESPONSE_ERROR` with `.get()` and a descriptive fallback in `Response.error`, `MessageError.__init__`, and `MessageParseError.__init__`
- Prevents `KeyError` when the device returns an unmapped status code

## Context

When a Kaleidescape device returns an error status code not defined in `const.RESPONSE_ERROR` (e.g. code 28 from a `GetScreenMask2` request during power-on), the `Response.error` property raises `KeyError` instead of producing a proper `MessageError`. Since `_handle_event` dispatches via `asyncio.create_task` with no exception handling, this silently kills the refresh task and leaves device state stale.

Fixes #13
