### PR TITLE
Fix _response_handler to exit on unhandled exceptions

### DIFF
--- a/kaleidescape/connection.py
+++ b/kaleidescape/connection.py
@@ -148,6 +148,8 @@ class Connection:
                 _LOGGER.exception(
                     "Unhandled exception %s('%s')", type(err).__name__, err
                 )
+                asyncio.create_task(self._handle_connection_error(err))
+                return
 
     async def _handle_connection_error(self, err: Exception):
         """Handle connection failures and schedule reconnect."""

--- a/tests/test_b_connection.py
+++ b/tests/test_b_connection.py
@@ -1,10 +1,14 @@
 """Tests for connection module."""
 
+import asyncio
+from unittest.mock import patch
+
 import pytest
 
 from kaleidescape.connection import Connection
 from kaleidescape.const import STATE_CONNECTED, STATE_DISCONNECTED, STATE_RECONNECTING
 from kaleidescape.dispatcher import Dispatcher
+from kaleidescape.message import Response
 
 from . import create_signal
 from .emulator import Emulator
@@ -135,3 +139,35 @@ async def test_reconnect_cancelled(emulator):
 
     await connection.disconnect()
     assert connection.state == STATE_DISCONNECTED
+
+
+@pytest.mark.asyncio
+async def test_unhandled_exception_triggers_reconnect(emulator: Emulator):
+    """Test that unhandled exceptions in _response_handler trigger reconnect."""
+    dispatcher = Dispatcher()
+    connection = Connection(dispatcher)
+
+    connect_signal = create_signal(dispatcher, STATE_CONNECTED)
+    disconnect_signal = create_signal(dispatcher, STATE_DISCONNECTED)
+
+    await connection.connect(
+        "127.0.0.1", port=10001, timeout=1, reconnect=True, reconnect_delay=0.5
+    )
+    await connect_signal.wait()
+    assert connection.state == STATE_CONNECTED
+    connect_signal.clear()
+
+    # Patch Response.factory to raise an unexpected exception, simulating an
+    # unhandled error in the response handler loop.
+    with patch.object(Response, "factory", side_effect=RuntimeError("simulated")):
+        await emulator.send_event(["01"], 0, "DEVICE_POWER_STATE", ["0"])
+        await asyncio.wait_for(disconnect_signal.wait(), timeout=2)
+
+    # Handler should have exited and triggered reconnect
+    assert connection.state == STATE_RECONNECTING
+
+    # Reconnect should succeed with factory restored
+    await connect_signal.wait()
+    assert connection.state == STATE_CONNECTED
+
+    await connection.disconnect()


### PR DESCRIPTION
## Summary

- The broad `except Exception` clause in `Connection._response_handler` catches errors but doesn't exit the loop or trigger reconnect, turning any unexpected exception into an infinite error spam loop (~200 errors/second)
- This was discovered while debugging a `RuntimeError: readuntil() called while another coroutine is already waiting for incoming data` crash in a consumer integration, where two `_response_handler` tasks ended up reading from the same `StreamReader`
- The fix adds `_handle_connection_error()` + `return` to the catch-all, mirroring the existing `IncompleteReadError`/`OSError` handling — this tears down the broken connection and lets auto-reconnect start clean

This change is a safety net so that *any* unexpected error in the response handler results in a clean teardown and reconnect rather than an infinite loop.
