### PR TITLE
Fix Device.disconnect() not cancelling reconnect task

### DIFF
--- a/kaleidescape/device.py
+++ b/kaleidescape/device.py
@@ -100,9 +100,6 @@ class Device:
 
     async def disconnect(self) -> None:
         """Disconnect from hardware."""
-        if not self.is_connected:
-            return
-
         await self._connection.disconnect()
 
     # noinspection PyTypeChecker

--- a/tests/test_d_device.py
+++ b/tests/test_d_device.py
@@ -41,6 +41,29 @@ async def test_connect(emulator: Emulator):
 
 
 @pytest.mark.asyncio
+async def test_disconnect_during_reconnect(emulator: Emulator):
+    """Test Device.disconnect() cancels reconnect in STATE_RECONNECTING."""
+    device = Device("127.0.0.1", port=10001, reconnect=True, reconnect_delay=0.5)
+
+    connect_signal = create_signal(device.dispatcher, const.STATE_CONNECTED)
+    disconnect_signal = create_signal(device.dispatcher, const.STATE_DISCONNECTED)
+
+    await device.connect()
+    await connect_signal.wait()
+    assert device.is_connected
+
+    # Drop connection to trigger library reconnect
+    await emulator.stop()
+    await disconnect_signal.wait()
+    assert device.connection.state == const.STATE_RECONNECTING
+
+    # Device.disconnect() should work even during STATE_RECONNECTING
+    await device.disconnect()
+    assert device.connection.state == const.STATE_DISCONNECTED
+    assert not device.is_connected
+
+
+@pytest.mark.asyncio
 async def test_get_available_devices(emulator: Emulator):
     """Test get available devices."""
     device = Device("127.0.0.1", port=10001)


### PR DESCRIPTION
## Summary
- `Device.disconnect()` silently does nothing when called during `STATE_RECONNECTING`
- The `is_connected` guard prevents `Connection.disconnect()` from being reached, leaving the reconnect task running
- Remove the redundant guard — `Connection.disconnect()` already handles idempotency by checking `STATE_DISCONNECTED`

Discovered while building an integration that calls `disconnect()` before `connect()` to ensure a clean connection state. When the library is mid-reconnect, `Device.disconnect()` returns early because `is_connected` is `False` during `STATE_RECONNECTING`, leaving the reconnect task active and causing dual-handler race conditions on the next `connect()`.