### PR TITLE
Refresh device state after auto-reconnect

### DIFF
--- a/kaleidescape/connection.py
+++ b/kaleidescape/connection.py
@@ -29,12 +29,16 @@ class Connection:
         self,
         dispatcher: Dispatcher,
         on_event: Callable[[Response], Coroutine[object, object, object]] | None = None,
+        on_reconnect: Callable[[], Coroutine[object, object, object]] | None = None,
     ) -> None:
         """Initializes connection."""
         self._dispatcher = dispatcher
         self._on_event: (
             Callable[[Response], Coroutine[object, object, object]] | None
         ) = on_event
+        self._on_reconnect: (
+            Callable[[], Coroutine[object, object, object]] | None
+        ) = on_reconnect
 
         self._ip: str | None = None
         self._port: int | None = None
@@ -182,6 +186,13 @@ class Connection:
                     await asyncio.sleep(self._reconnect_delay)
                 else:
                     self._reconnect_task = None
+                    if self._on_reconnect:
+                        try:
+                            await self._on_reconnect()
+                        except Exception:  # pylint: disable=broad-except
+                            _LOGGER.exception(
+                                "Post-reconnect callback failed for %s", self._ip
+                            )
                     _LOGGER.info("Reconnected to %s", self._ip)
         except Exception as err:  # pylint: disable=broad-except
             _LOGGER.exception("Unhandled exception %s('%s')", type(err).__name__, err)

--- a/kaleidescape/device.py
+++ b/kaleidescape/device.py
@@ -50,7 +50,9 @@ class Device:
         self._reconnect_delay = reconnect_delay
 
         self._dispatcher = Dispatcher()
-        self._connection = Connection(self._dispatcher, self._handle_event)
+        self._connection = Connection(
+            self._dispatcher, self._handle_event, on_reconnect=self._on_reconnect
+        )
 
         self.system = System()
         self.power = Power()
@@ -101,6 +103,18 @@ class Device:
     async def disconnect(self) -> None:
         """Disconnect from hardware."""
         await self._connection.disconnect()
+
+    async def _on_reconnect(self) -> None:
+        """Refresh device state after auto-reconnect."""
+        results = await asyncio.gather(
+            self._get_device_power_state(),
+            self._get_system_readiness_state(),
+        )
+        self._update_device_power_state(cast(messages.DevicePowerState, results[0]))
+        self._update_system_readiness_state(
+            cast(messages.SystemReadinessState, results[1])
+        )
+        await self.refresh()
 
     # noinspection PyTypeChecker
     async def refresh(self) -> None:

--- a/tests/test_b_connection.py
+++ b/tests/test_b_connection.py
@@ -171,3 +171,41 @@ async def test_unhandled_exception_triggers_reconnect(emulator: Emulator):
     assert connection.state == STATE_CONNECTED
 
     await connection.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_reconnect_calls_on_reconnect(emulator: Emulator):
+    """Test on_reconnect callback is called after successful reconnect."""
+    dispatcher = Dispatcher()
+    callback_called = asyncio.Event()
+
+    async def on_reconnect():
+        callback_called.set()
+
+    connection = Connection(dispatcher, on_reconnect=on_reconnect)
+
+    connect_signal = create_signal(dispatcher, STATE_CONNECTED)
+    disconnect_signal = create_signal(dispatcher, STATE_DISCONNECTED)
+
+    await connection.connect(
+        "127.0.0.1", port=10001, timeout=1, reconnect=True, reconnect_delay=0.5
+    )
+    await connect_signal.wait()
+    assert connection.state == STATE_CONNECTED
+
+    # Callback should NOT have been called during initial connect
+    assert not callback_called.is_set()
+
+    # Drop and reconnect
+    connect_signal.clear()
+    await emulator.stop()
+    await disconnect_signal.wait()
+
+    await emulator.start()
+    await connect_signal.wait()
+    assert connection.state == STATE_CONNECTED
+
+    # Callback should have been called after reconnect
+    assert callback_called.is_set()
+
+    await connection.disconnect()

--- a/tests/test_d_device.py
+++ b/tests/test_d_device.py
@@ -287,3 +287,42 @@ async def test_set_volume_muted(emulator: Emulator):
         await device.set_volume_muted(1)  # type: ignore[arg-type]
 
     await device.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_refresh_after_reconnect(emulator: Emulator):
+    """Test device state is refreshed after auto-reconnect."""
+    device = Device("127.0.0.1", port=10001, reconnect=True, reconnect_delay=0.5)
+
+    connect_signal = create_signal(device.dispatcher, const.STATE_CONNECTED)
+    disconnect_signal = create_signal(device.dispatcher, const.STATE_DISCONNECTED)
+
+    await device.connect()
+    await connect_signal.wait()
+    assert device.is_connected
+    assert device.power.state == const.DEVICE_POWER_STATE_STANDBY
+
+    # Change emulator response so power state differs after reconnect
+    emulator.register_mock_command(
+        ("01",),
+        messages.GetDevicePowerState.name,
+        (SUCCESS, messages.DevicePowerState.name, ["1", "1"]),
+    )
+
+    # Drop connection
+    connect_signal.clear()
+    await emulator.stop()
+    await disconnect_signal.wait()
+
+    # Reconnect - device state should be refreshed automatically
+    await emulator.start()
+    await connect_signal.wait()
+    assert device.is_connected
+
+    # Give the on_reconnect callback a moment to complete
+    await asyncio.sleep(0.1)
+
+    # Power state should reflect the new emulator response
+    assert device.power.state == const.DEVICE_POWER_STATE_ON
+
+    await device.disconnect()


### PR DESCRIPTION
## Problem

After a successful auto-reconnect, the library re-establishes the socket and dispatches `STATE_CONNECTED`, but the `Device` dataclasses (power, movie, OSD, play status, etc.) still hold stale values from before the disconnect. Every consumer must independently subscribe to `STATE_CONNECTED`, call `device.refresh()`, and handle exceptions.

In practice, the Home Assistant kaleidescape integration does not call `refresh()` after reconnect, meaning entities display stale data until the next device-initiated event happens to update them.

## Fix

Add an `on_reconnect` callback to `Connection`, following the existing `on_event` pattern. `Device` uses this callback to re-fetch power/readiness state and call `refresh()` after a successful reconnect. The callback is awaited before `STATE_CONNECTED` is dispatched — so consumers see fresh state when they handle the signal.

This is non-breaking: existing consumers continue to work unchanged. Those that already call `refresh()` in their `STATE_CONNECTED` handler would get a harmless redundant refresh, and can simplify their code over time.