### PR TITLE
Dispatch STATE_CONNECTED only on auto-reconnect

### DIFF
--- a/kaleidescape/connection.py
+++ b/kaleidescape/connection.py
@@ -116,7 +116,6 @@ class Connection:
         self._response_handler_task = asyncio.create_task(self._response_handler())
 
         self._state = const.STATE_CONNECTED
-        self._dispatcher.send(const.STATE_CONNECTED)
 
     async def _response_handler(self) -> None:
         """Main loop receiving responses and events from hardware device."""
@@ -182,6 +181,7 @@ class Connection:
                     await asyncio.sleep(self._reconnect_delay)
                 else:
                     self._reconnect_task = None
+                    self._dispatcher.send(const.STATE_CONNECTED)
                     _LOGGER.info("Reconnected to %s", self._ip)
         except Exception as err:  # pylint: disable=broad-except
             _LOGGER.exception("Unhandled exception %s('%s')", type(err).__name__, err)

--- a/tests/test_b_connection.py
+++ b/tests/test_b_connection.py
@@ -52,13 +52,11 @@ async def test_connect_timeout():
 
 @pytest.mark.asyncio
 async def test_connect_succeeds(emulator: Emulator):
-    """Test connect updates state and emits signal."""
+    """Test connect updates state without emitting signal."""
     dispatcher = Dispatcher()
     connection = Connection(dispatcher)
     assert connection.state == STATE_DISCONNECTED
-    signal = create_signal(dispatcher, STATE_CONNECTED)
     await connection.connect("127.0.0.1", port=10001, timeout=1)
-    await signal.wait()
     assert connection.ip == "127.0.0.1"
     assert connection.port == 10001
     assert connection.timeout == 1
@@ -95,13 +93,14 @@ async def test_reconnect_during_event(emulator: Emulator):
     connect_signal = create_signal(dispatcher, STATE_CONNECTED)
     disconnect_signal = create_signal(dispatcher, STATE_DISCONNECTED)
 
-    # Assert connection
+    # Initial connect - no STATE_CONNECTED signal expected
     await connection.connect(
         "127.0.0.1", port=10001, timeout=1, reconnect=True, reconnect_delay=1
     )
-    await connect_signal.wait()
     assert connection.state == STATE_CONNECTED
-    connect_signal.clear()
+
+    # Allow emulator to register the client before stopping
+    await asyncio.sleep(0.1)
 
     # Assert transitions to reconnecting and emits disconnect signal
     await emulator.stop()
@@ -122,15 +121,16 @@ async def test_reconnect_cancelled(emulator):
     dispatcher = Dispatcher()
     connection = Connection(dispatcher)
 
-    connect_signal = create_signal(dispatcher, STATE_CONNECTED)
     disconnect_signal = create_signal(dispatcher, STATE_DISCONNECTED)
 
-    # Assert open and fires connected
+    # Initial connect - no STATE_CONNECTED signal expected
     await connection.connect(
         "127.0.0.1", port=10001, timeout=1, reconnect=True, reconnect_delay=0.5
     )
-    await connect_signal.wait()
     assert connection.state == STATE_CONNECTED
+
+    # Allow emulator to register the client before stopping
+    await asyncio.sleep(0.1)
 
     # Assert transitions to reconnecting and emits disconnect signal
     await emulator.stop()
@@ -153,9 +153,10 @@ async def test_unhandled_exception_triggers_reconnect(emulator: Emulator):
     await connection.connect(
         "127.0.0.1", port=10001, timeout=1, reconnect=True, reconnect_delay=0.5
     )
-    await connect_signal.wait()
     assert connection.state == STATE_CONNECTED
-    connect_signal.clear()
+
+    # Allow emulator to register the client
+    await asyncio.sleep(0)
 
     # Patch Response.factory to raise an unexpected exception, simulating an
     # unhandled error in the response handler loop.
@@ -166,8 +167,33 @@ async def test_unhandled_exception_triggers_reconnect(emulator: Emulator):
     # Handler should have exited and triggered reconnect
     assert connection.state == STATE_RECONNECTING
 
-    # Reconnect should succeed with factory restored
+    # Reconnect should succeed and emit STATE_CONNECTED
     await connect_signal.wait()
     assert connection.state == STATE_CONNECTED
+
+    await connection.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_connect_does_not_dispatch_connected(emulator: Emulator):
+    """Test that initial connect does not dispatch STATE_CONNECTED signal."""
+    dispatcher = Dispatcher()
+    connection = Connection(dispatcher)
+    signal_received = False
+
+    async def on_signal(event, *args):
+        nonlocal signal_received
+        if event == STATE_CONNECTED:
+            signal_received = True
+
+    dispatcher.connect(on_signal)
+
+    await connection.connect("127.0.0.1", port=10001, timeout=1)
+    assert connection.state == STATE_CONNECTED
+
+    # Give any pending tasks a chance to run
+    await asyncio.sleep(0.05)
+
+    assert not signal_received, "STATE_CONNECTED should not be dispatched during initial connect"
 
     await connection.disconnect()

--- a/tests/test_c_command.py
+++ b/tests/test_c_command.py
@@ -65,13 +65,14 @@ async def test_reconnect_during_command(emulator: Emulator):
     connect_signal = create_signal(dispatcher, STATE_CONNECTED)
     disconnect_signal = create_signal(dispatcher, STATE_DISCONNECTED)
 
-    # Assert connection
+    # Initial connect - no STATE_CONNECTED signal expected
     await connection.connect(
         "127.0.0.1", port=10001, timeout=1, reconnect=True, reconnect_delay=1
     )
-    await connect_signal.wait()
     assert connection.state == const.STATE_CONNECTED
-    connect_signal.clear()
+
+    # Allow emulator to register the client before stopping
+    await asyncio.sleep(0.1)
 
     # Break connection
     await emulator.stop()

--- a/tests/test_d_device.py
+++ b/tests/test_d_device.py
@@ -45,12 +45,13 @@ async def test_disconnect_during_reconnect(emulator: Emulator):
     """Test Device.disconnect() cancels reconnect in STATE_RECONNECTING."""
     device = Device("127.0.0.1", port=10001, reconnect=True, reconnect_delay=0.5)
 
-    connect_signal = create_signal(device.dispatcher, const.STATE_CONNECTED)
     disconnect_signal = create_signal(device.dispatcher, const.STATE_DISCONNECTED)
 
     await device.connect()
-    await connect_signal.wait()
     assert device.is_connected
+
+    # Allow emulator to register the client before stopping
+    await asyncio.sleep(0.1)
 
     # Drop connection to trigger library reconnect
     await emulator.stop()


### PR DESCRIPTION
## Summary

`Connection._connect()` dispatches `STATE_CONNECTED` unconditionally. 

Since `_connect()` is called from both `Connection.connect()` (initial) and `Connection._reconnect()` (auto-reconnect), consumers receive the signal in both cases.

During initial connect, this signal is redundant — the caller already knows the connection succeeded because `await device.connect()` returned without raising. The signal's value is in notifying consumers about asynchronous events they didn't initiate, which only applies to auto-reconnect.

In practice, this forces consumers to distinguish initial connect from reconnect. 

For example, the [Unfolded Circle kaleidescape integration](https://github.com/johncarey70/uc-integration-kaleidescape) needs a `_connecting` guard flag as a workaround because the `STATE_CONNECTED` handler runs during `Device.connect()` while device info is still being fetched via `asyncio.gather()` — causing queries against incomplete state.

## Suggested change

There were tests that asserted the prior behavior, so this may have been an intentional design choice. But here is a suggested change.  

Move `self._dispatcher.send(const.STATE_CONNECTED)` from `_connect()` to the `else` block of `_reconnect()`. `_connect()` still sets `self._state = const.STATE_CONNECTED` so all state checks (including `is_connected`) work correctly. 

The signal now only fires for asynchronous reconnection events.

## Impact on consumers

The Home Assistant kaleidescape integration registers a generic dispatcher callback that calls `async_write_ha_state()` for every dispatched event — it does not check the event type or specifically handle `STATE_CONNECTED`. Suppressing the signal during initial connect removes one redundant state write during setup, which is harmless.

Any consumer that currently waits for `STATE_CONNECTED` during initial connect can simply check `device.is_connected` or `connection.state` after `await connect()` returns, which is both simpler and more reliable.

## Tests

- Updated all existing tests that waited for `STATE_CONNECTED` during initial connect to assert `connection.state` directly instead
- Added `test_connect_does_not_dispatch_connected` to explicitly verify the signal is not dispatched on initial connect