### PR TITLE
Use __version__ for syslog identification

### DIFF
--- a/kaleidescape/__init__.py
+++ b/kaleidescape/__init__.py
@@ -1,11 +1,11 @@
 """A python client library for controlling Kaleidescape devices via the Kaleidescape
 Control Protocol."""
 
+__version__ = "1.1.6"
+
 from . import const
 from .device import Device
 from .dispatcher import Dispatcher
 from .error import KaleidescapeError
 
 __all__ = ["const", "Device", "Dispatcher", "KaleidescapeError"]
-
-__version__ = "1.1.6"

--- a/kaleidescape/device.py
+++ b/kaleidescape/device.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import dataclass
-from importlib.metadata import version as pkg_version
 from typing import TYPE_CHECKING, TypeVar, cast
 
 from . import const
@@ -108,9 +107,12 @@ class Device:
 
     async def _send_syslog_identification(self) -> None:
         """Send module identification to syslog for Kaleidescape support."""
-        ver = pkg_version("pykaleidescape")
+        from . import __version__
+
         await self._send(
-            messages.SendToSyslog, 0, ["INFORMATION", f"pykaleidescape version {ver}"]
+            messages.SendToSyslog,
+            0,
+            ["INFORMATION", f"pykaleidescape version {__version__}"],
         )
 
     async def disconnect(self) -> None:

--- a/tests/test_d_device.py
+++ b/tests/test_d_device.py
@@ -1,6 +1,7 @@
 """Tests for device module."""
 
 import asyncio
+from unittest.mock import patch
 
 import pytest
 
@@ -77,6 +78,29 @@ async def test_connect_sends_syslog_identification(emulator: Emulator):
     assert len(syslog_requests) == 1
     assert syslog_requests[0].fields[0] == "INFORMATION"
     assert syslog_requests[0].fields[1] == f"pykaleidescape version {kaleidescape.__version__}"
+
+    await device.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_send_syslog_identification_uses_dunder_version(emulator: Emulator):
+    """Test _send_syslog_identification reads from __version__, not importlib.metadata.
+
+    The commit switched from importlib.metadata.version() to kaleidescape.__version__
+    because importlib.metadata fails in PyInstaller bundles. This test patches __version__
+    to a sentinel value and confirms that exact value appears in the syslog message,
+    proving the method uses the module attribute directly.
+    """
+    sentinel = "0.0.0-test-sentinel"
+    with patch("kaleidescape.device.__version__", sentinel):
+        device = Device("127.0.0.1", port=10001)
+        await device.connect()
+
+    syslog_requests = [
+        r for r in emulator.received_requests if r.name == "SEND_TO_SYSLOG"
+    ]
+    assert len(syslog_requests) == 1
+    assert syslog_requests[0].fields[1] == f"pykaleidescape version {sentinel}"
 
     await device.disconnect()
 


### PR DESCRIPTION
## Summary

Fixes `PackageNotFoundError` in `_send_syslog_identification` when running in PyInstaller-bundled deployments.

PR #21 used `importlib.metadata.version("pykaleidescape")` to look up the package version at runtime. This was a reasonable approach but doesn't work in environments where package dist-info metadata isn't available — notably PyInstaller, which strips it by default.

`kaleidescape.__version__` is already the single source of truth for the version (pyproject.toml reads from it via `[tool.setuptools.dynamic]`), so using it directly is both simpler and universally compatible.