### PR TITLE
Fix CI hang in reconnect tests after STATE_CONNECTED scope change

### DIFF
--- a/tests/test_b_connection.py
+++ b/tests/test_b_connection.py
@@ -214,14 +214,12 @@ async def test_reconnect_calls_on_reconnect(emulator: Emulator):
     await connection.connect(
         "127.0.0.1", port=10001, timeout=1, reconnect=True, reconnect_delay=0.5
     )
-    await connect_signal.wait()
     assert connection.state == STATE_CONNECTED
 
     # Callback should NOT have been called during initial connect
     assert not callback_called.is_set()
 
     # Drop and reconnect
-    connect_signal.clear()
     await emulator.stop()
     await disconnect_signal.wait()
 

--- a/tests/test_b_connection.py
+++ b/tests/test_b_connection.py
@@ -219,6 +219,9 @@ async def test_reconnect_calls_on_reconnect(emulator: Emulator):
     # Callback should NOT have been called during initial connect
     assert not callback_called.is_set()
 
+    # Allow emulator to register the client before stopping
+    await asyncio.sleep(0.1)
+
     # Drop and reconnect
     await emulator.stop()
     await disconnect_signal.wait()

--- a/tests/test_d_device.py
+++ b/tests/test_d_device.py
@@ -350,6 +350,9 @@ async def test_refresh_after_reconnect(emulator: Emulator):
         (SUCCESS, messages.DevicePowerState.name, ["1", "1"]),
     )
 
+    # Allow emulator to register the client before stopping
+    await asyncio.sleep(0.1)
+
     # Drop connection
     await emulator.stop()
     await disconnect_signal.wait()

--- a/tests/test_d_device.py
+++ b/tests/test_d_device.py
@@ -340,7 +340,6 @@ async def test_refresh_after_reconnect(emulator: Emulator):
     disconnect_signal = create_signal(device.dispatcher, const.STATE_DISCONNECTED)
 
     await device.connect()
-    await connect_signal.wait()
     assert device.is_connected
     assert device.power.state == const.DEVICE_POWER_STATE_STANDBY
 
@@ -352,7 +351,6 @@ async def test_refresh_after_reconnect(emulator: Emulator):
     )
 
     # Drop connection
-    connect_signal.clear()
     await emulator.stop()
     await disconnect_signal.wait()
 

--- a/tests/test_d_device.py
+++ b/tests/test_d_device.py
@@ -92,7 +92,7 @@ async def test_send_syslog_identification_uses_dunder_version(emulator: Emulator
     proving the method uses the module attribute directly.
     """
     sentinel = "0.0.0-test-sentinel"
-    with patch("kaleidescape.device.__version__", sentinel):
+    with patch("kaleidescape.__version__", sentinel):
         device = Device("127.0.0.1", port=10001)
         await device.connect()
 


### PR DESCRIPTION
## Problem

Every CI run on `main` since PR #18 merged (`#19`, `#20`, `#21`, `v1.1.6` release, `#22`) was cancelled at the 6-hour job timeout. Job logs show pytest gets through 34 tests, then hangs forever on test #35 (`test_reconnect_calls_on_reconnect`).

```
2026-04-05T14:57:33Z  pytest -q
...
2026-04-05T20:57:19Z  ..................................
2026-04-05T20:57:19Z  ##[error]The runner has received a shutdown signal.
```

This PR fixes the hang and also fixes a separate failing test that the hang was hiding.

## Root cause 1: hanging reconnect tests

The two tests added in PR #18 (`Refresh device state after auto-reconnect`) had **two** bugs that combined to produce an infinite hang:

### Bug A: waiting for STATE_CONNECTED on initial connect
After PR #19 (`Dispatch STATE_CONNECTED only on auto-reconnect`) moved the dispatch out of `_connect()`, `await connect_signal.wait()` after initial `connect()` waits forever. PR #19 updated other tests to assert `state == STATE_CONNECTED` directly, but PR #19 was opened before PR #18 merged so the two tests added by #18 were not on its radar.

### Bug B: missing sleep before `emulator.stop()`
Other reconnect tests (`test_reconnect_during_event`, `test_reconnect_cancelled`) include `await asyncio.sleep(0.1)` between the initial `connect()` and `emulator.stop()` to let the emulator's `_handle_client` callback register the client. PR #18's two tests omit it. Without the pause, `emulator.stop()` finds an empty `_clients` list, doesn't disconnect anything, the test client never sees EOF, and `STATE_DISCONNECTED` is never dispatched — `disconnect_signal.wait()` hangs.

### Fix

1. Drop `await connect_signal.wait()` after the initial connect; assert `state == STATE_CONNECTED` directly (matches the pattern used by tests updated in PR #19).
2. Drop the now-redundant `connect_signal.clear()` calls — the signal is no longer set during initial connect.
3. Add `await asyncio.sleep(0.1)` before `emulator.stop()` (matches the pattern used by other reconnect tests).

## Root cause 2: bad mock.patch target

Once the hang was fixed and CI ran to completion, `tests/test_d_device.py::test_send_syslog_identification_uses_dunder_version` (added in PR #22) failed:

```
AttributeError: <module 'kaleidescape.device'...> does not have the attribute '__version__'
```

The test patched `kaleidescape.device.__version__`, but `device.py` does `from . import __version__` *inside* `_send_syslog_identification`, so it's a function-local, not a module attribute. `mock.patch` requires the attribute to exist on the target.

This test never executed in CI before merge because PR #22's runs were cancelled by the same hang.

### Fix

Patch `kaleidescape.__version__` (the actual location). The function's `from . import __version__` re-reads it on each call, so the patched sentinel propagates through.

